### PR TITLE
Fix issue with Start RTS endpoint

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@dolbyio/dolbyio-rest-apis-client",
-    "version": "4.0.0",
+    "version": "4.0.1",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@dolbyio/dolbyio-rest-apis-client",
-            "version": "4.0.0",
+            "version": "4.0.1",
             "license": "MIT",
             "dependencies": {
                 "follow-redirects": "^1.15.2"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@dolbyio/dolbyio-rest-apis-client",
-    "version": "4.0.0",
+    "version": "4.0.1",
     "description": "Node.JS wrapper for the dolby.io REST APIs",
     "main": "dist/index.js",
     "scripts": {

--- a/src/communications/streaming.ts
+++ b/src/communications/streaming.ts
@@ -121,7 +121,7 @@ export async function startRts(options: ExpandRecursively<MixOptions>): Promise<
 
     const requestOptions = {
         hostname: Urls.getCommsHostname(),
-        path: `/v2/conferences/mix/${options.conferenceId}/rts/start`,
+        path: `/v3/conferences/mix/${options.conferenceId}/rts/start`,
         headers: {
             Accept: 'application/json',
             'Content-Type': 'application/json',
@@ -145,7 +145,7 @@ export async function startRts(options: ExpandRecursively<MixOptions>): Promise<
 export const stopRts = async (accessToken: JwtToken, conferenceId: string): Promise<void> => {
     const options = {
         hostname: Urls.getCommsHostname(),
-        path: `/v2/conferences/mix/${conferenceId}/rts/stop`,
+        path: `/v3/conferences/mix/${conferenceId}/rts/stop`,
         headers: {
             Accept: 'application/json',
             'Content-Type': 'application/json',


### PR DESCRIPTION
Start RTS endpoint - https://docs.dolby.io/communications-apis/reference/start-rts - is using `/v3/` endpoint.