### PR TITLE
Fix `downloadFile`

### DIFF
--- a/src/media/io.ts
+++ b/src/media/io.ts
@@ -102,7 +102,7 @@ export const downloadFile = async (accessToken: JwtToken, dlbUrl: string, filePa
 
     const requestOptions: RequestOptions = {
         hostname: downloadUrl.substring(0, idx),
-        path: downloadUrl.substring(idx + 1),
+        path: downloadUrl.substring(idx),
         headers: {},
     };
 


### PR DESCRIPTION
A very minor fix, in a great library!

`downloadFile` slices away the leading slash (`/`) of the path. Example:

```js
const jwt = await dolbyio.authentication.getApiAccessToken(
    process.env.DOLBY_APP_KEY,
    process.env.DOLBY_APP_SECRET
);
const upload = await dolbyio.media.io.uploadFile(jwt, 'dlb://test.mp4', 'video.mp4');
console.log(upload); // should be undefined
const download = await dolbyio.media.io.downloadFile(jwt, 'dlb://test.mp4', 'download.mp4');
console.log(download);
```

Output (Notice the lack of `/` after `amazonaws.com` in the `GET` request):
```
[POST] 200 - https://api.dolby.io/v1/auth/token
[POST] 200 - https://api.dolby.com/media/input
[PUT] 200 - https://media-api-proxfyprug.s3-accelerate.amazonaws.com/89c3c4bd-5ee3-4550-8d09-b77670658124/test.mp4?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Content-Sha256=...
undefined
[POST] 200 - https://api.dolby.com/media/output
[GET] 400 - https://media-api-proxfyprug.s3-accelerate.amazonaws.com89c3c4bd-5ee3-4550-8d09-b77670658124/test.mp4?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Content-Sha256=...

node:internal/process/esm_loader:97
    internalBinding('errors').triggerUncaughtException(
                              ^
This request has been rejected with the response code 400
Thrown at:
    at loadESM (node:internal/process/esm_loader:97:31)
    at processTicksAndRejections (node:internal/process/task_queues:95:5)

Node.js v18.14.2
```